### PR TITLE
Fix for the Clone method not copying over the CreatedAt, CreatedBy, L…

### DIFF
--- a/Utils.DOM.Tests/DomConnectionMockTests.cs
+++ b/Utils.DOM.Tests/DomConnectionMockTests.cs
@@ -4,10 +4,13 @@
 	using System.Collections.Generic;
 	using System.Linq;
 
+	using FluentAssertions;
+
 	using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 	using Skyline.DataMiner.Net;
 	using Skyline.DataMiner.Net.Apps.DataMinerObjectModel;
+	using Skyline.DataMiner.Net.ManagerStore;
 	using Skyline.DataMiner.Net.Messages;
 	using Skyline.DataMiner.Net.Messages.SLDataGateway;
 	using Skyline.DataMiner.Net.SubscriptionFilters;
@@ -148,6 +151,25 @@
 			CollectionAssert.AreEquivalent(Array.Empty<DomInstance>(), receivedEvent.Created);
 			CollectionAssert.AreEquivalent(Array.Empty<DomInstance>(), receivedEvent.Updated);
 			CollectionAssert.AreEquivalent(new[] { TestData.Instance1 }, receivedEvent.Deleted);
+		}
+
+		[TestMethod]
+		public void DomConnectionMock_ITrackProperties()
+		{
+			// arrange
+			var connection = new DomConnectionMock();
+			var domHelper = new DomHelper(connection.HandleMessages, "module");
+
+			// act
+			domHelper.DomInstances.CreateOrUpdate(new[] { TestData.Instance1, TestData.Instance2 }.ToList());
+			var result = domHelper.DomInstances.ReadAll();
+
+			// assert
+			result.Should().HaveCount(2);
+			result[0].As<ITrackCreatedAt>().CreatedAt.Should().NotBe(default);
+			result[0].As<ITrackCreatedBy>().CreatedBy.Should().NotBeNullOrEmpty();
+			result[0].As<ITrackLastModified>().LastModified.Should().NotBe(default);
+			result[0].As<ITrackLastModifiedBy>().LastModifiedBy.Should().NotBeNullOrEmpty();
 		}
 	}
 }

--- a/Utils.DOM/Extensions/DomInstanceExtensions.cs
+++ b/Utils.DOM/Extensions/DomInstanceExtensions.cs
@@ -5,6 +5,7 @@
 	using System.Linq;
 
 	using Skyline.DataMiner.Net.Apps.DataMinerObjectModel;
+	using Skyline.DataMiner.Net.ManagerStore;
 	using Skyline.DataMiner.Net.Messages.SLDataGateway;
 	using Skyline.DataMiner.Net.Sections;
 
@@ -158,6 +159,30 @@
 				?? throw new ArgumentException($"Couldn't find section definition with name '{definitionName}'", nameof(definitionName));
 
 			return instance.GetSectionsWithDefinition(definition);
+		}
+
+		/// <summary>
+		/// Creates a deep clone of the specified <see cref="DomInstance"/>, including audit tracking properties.
+		/// </summary>
+		/// <param name="instance">The <see cref="DomInstance"/> to clone.</param>
+		/// <returns>
+		/// A deep clone of the <see cref="DomInstance"/>, with <see cref="ITrackCreatedAt.CreatedAt"/>, 
+		/// <see cref="ITrackCreatedBy.CreatedBy"/>, <see cref="ITrackLastModified.LastModified"/>, and 
+		/// <see cref="ITrackLastModifiedBy.LastModifiedBy"/> properties copied from the original instance.
+		/// </returns>
+		/// <remarks>
+		/// The returned clone is a new instance with the same data and audit tracking information as the original.
+		/// </remarks>
+		public static DomInstance DeepClone(this DomInstance instance)
+		{
+			var clone = (DomInstance)instance.Clone();
+
+			((ITrackCreatedAt)clone).CreatedAt = ((ITrackCreatedAt)instance).CreatedAt;
+			((ITrackCreatedBy)clone).CreatedBy = ((ITrackCreatedBy)instance).CreatedBy;
+			((ITrackLastModified)clone).LastModified = ((ITrackLastModified)instance).LastModified;
+			((ITrackLastModifiedBy)clone).LastModifiedBy = ((ITrackLastModifiedBy)instance).LastModifiedBy;
+
+			return clone;
 		}
 	}
 }

--- a/Utils.DOM/UnitTesting/DomSLNetMessageHandler.cs
+++ b/Utils.DOM/UnitTesting/DomSLNetMessageHandler.cs
@@ -282,15 +282,15 @@
 				case ManagerStoreReadRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instances = request.Query.ExecuteInMemory(module.Instances.Values).ToList();
-						response = new ManagerStoreCrudResponse<DomInstance>(instances.Clone());
+						var instances = request.Query.ExecuteInMemory(module.Instances.Values).Select(instance => instance.DeepClone()).ToList();
+						response = new ManagerStoreCrudResponse<DomInstance>(instances);
 						return true;
 					}
 
 				case ManagerStoreCreateRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instance = (DomInstance)request.Object.Clone();
+						var instance = request.Object.DeepClone();
 
 						var utcNow = DateTime.UtcNow;
 						((ITrackCreatedAt)instance).CreatedAt = utcNow;
@@ -316,7 +316,7 @@
 				case ManagerStoreUpdateRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instance = (DomInstance)request.Object.Clone();
+						var instance = request.Object.DeepClone();
 
 						var utcNow = DateTime.UtcNow;
 						((ITrackLastModified)instance).LastModified = utcNow;
@@ -342,7 +342,7 @@
 				case ManagerStoreDeleteRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instance = (DomInstance)request.Object.Clone();
+						var instance = request.Object.DeepClone();
 
 						var @event = new DomInstancesChangedEventMessage(-1, request.ModuleId);
 
@@ -368,7 +368,7 @@
 						var utcNow = DateTime.UtcNow;
 
 						var module = GetDomModule(request.ModuleId);
-						var instances = request.Objects.Clone();
+						var instances = request.Objects.Select(instance => instance.DeepClone()).ToList();
 
 						var @event = new DomInstancesChangedEventMessage(-1, request.ModuleId);
 
@@ -405,7 +405,7 @@
 				case ManagerStoreBulkDeleteRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instances = request.Objects.Clone();
+						var instances = request.Objects.Select(instance => instance.DeepClone()).ToList();
 
 						var successfulIds = new List<DomInstanceId>();
 						var unsuccessfulIds = new List<DomInstanceId>();
@@ -433,7 +433,7 @@
 					{
 						var module = GetDomModule(request.ModuleId);
 						var instances = request.Filter.ExecuteInMemory(module.Instances.Values).ToList();
-						var pagingHandler = new DomPagingHandler<DomInstance>(instances.Clone());
+						var pagingHandler = new DomPagingHandler<DomInstance>(instances.Select(instance => instance.DeepClone()));
 						module.PagingHandlers.TryAdd(pagingHandler.Cookie, pagingHandler);
 
 						var nextPage = pagingHandler.GetNextPage(request.PreferredPageSize, out var isLast);

--- a/Utils.DOM/Utils.DOM.csproj
+++ b/Utils.DOM/Utils.DOM.csproj
@@ -23,17 +23,17 @@
 		<RepositoryType>git</RepositoryType>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<PackageReference Include="Skyline.DataMiner.Dev.Common" Version="10.5.2" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
 			<_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<None Include="..\README.md" Pack="true" PackagePath="" />
 		<None Include="..\LICENSE.txt" Pack="true" PackagePath="" />


### PR DESCRIPTION
The .Clone method on the DomInstance object apparantly doesn't copy over the CreatedAt, CreatedBy, LastModified and LastModifiedBy properties. This means the Read breaks because we need the .Clone to returns a new instance object when reading objects.

I've added a DeepClone extension, that does the normal clone and then copies over the track properties too. If there are more missing ones we can add them to this method.