### PR TITLE
chore: migrate wrapper to call Master Workflow.yml directly

### DIFF
--- a/.github/workflows/DataMiner-CICD-NuGetSolution.yml
+++ b/.github/workflows/DataMiner-CICD-NuGetSolution.yml
@@ -20,16 +20,9 @@ jobs:
 
 # Note: Tagging will push the nupackage to nuget.org using the provided NUGETAPIKEY. You can tag both a prerelease version (a.b.c-xxxx) or a stable release (a.b.c).
   CICD:
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/NuGet Solution Master Workflow.yml@main
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@main
     with:
-      referenceName: ${{ github.ref_name }}
-      runNumber: ${{ github.run_number }}
-      referenceType: ${{ github.ref_type }}
-      repository: ${{ github.repository }}
-      owner: ${{ github.repository_owner }}
-      sonarCloudProjectName: "SkylineCommunications_Skyline.DataMiner.Utils.DOM"
+      sonarcloud-project-name: "SkylineCommunications_Skyline.DataMiner.Utils.DOM"
+      nuget-push-source: "https://api.nuget.org/v3/index.json"
     secrets:
-      sonarCloudToken: ${{ secrets.SONAR_TOKEN }}
-      pfx: ${{ secrets.PFX }}
-      pfxPassword: ${{ secrets.PFXPASSWORD }}
-      nugetApiKey: ${{ secrets.NUGETAPIKEY }}
+      NUGET_API_KEY: ${{ secrets.NUGETAPIKEY }}


### PR DESCRIPTION
This PR was opened automatically by the
**Wrapper Migration Workflow** in
`SkylineCommunications/_ReusableWorkflows`.

### What changed

The wrapper workflow file(s) in `.github/workflows/` were
updated to call
`SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml`
directly instead of the legacy
**nuget** master wrapper. Input and
secret names were renamed to the kebab-case / SHOUTING_CASE
names that `Master Workflow.yml` expects, and any obsolete
passthrough inputs (`referenceName`, `runNumber`,
`referenceType`, `repository`, `owner`, …) were dropped.

### Why

The legacy `NuGet Solution`, `Internal NuGet Solution` and
`DataMiner App Packages` master workflows are thin wrappers
that internally call `Master Workflow.yml`. Removing the
indirection:

- shortens the CI call chain by one job;
- exposes the full set of `Master Workflow.yml` inputs
  (e.g. `runs-on`) without us having to forward each one
  through every wrapper;
- lets us evolve the master inputs without breaking
  callers.

### Review checklist

- [ ] The rewrite preserves all `with:` values that were
      previously passed through (only the keys were
      renamed).
- [ ] All `secrets:` mappings are intact.
- [ ] If your wrapper job had extra steps or conditions
      around the legacy `uses:` call, verify they still
      make sense pointing at the master workflow.
- [ ] CI on this PR is green.

*Idempotent: re-running the legacy wrapper while this PR
is open will not create another one.*