### PR TITLE
feat: add coercion-aware filter evaluation and initial status to DOM mock

### DIFF
--- a/Utils.DOM.Tests/CoercingFilterEvaluatorTests.cs
+++ b/Utils.DOM.Tests/CoercingFilterEvaluatorTests.cs
@@ -1,0 +1,76 @@
+namespace Skyline.DataMiner.Utils.DOM.Tests
+{
+	using FluentAssertions;
+
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+	using Skyline.DataMiner.Net.Apps.DataMinerObjectModel;
+	using Skyline.DataMiner.Net.Messages.SLDataGateway;
+	using Skyline.DataMiner.Utils.DOM.Extensions;
+	using Skyline.DataMiner.Utils.DOM.UnitTesting;
+
+	[TestClass]
+	public class CoercingFilterEvaluatorTests
+	{
+		[TestMethod]
+		public void Read_FieldValueFilter_MatchesWhenLiteralTypeDiffersFromStoredValue()
+		{
+			// arrange - Instance1 stores "Field 2" as an int (123); the field descriptor is a long.
+			var helper = DomHelperMock.Create();
+			helper.SetDefinitions(new[] { TestData.Definition1 });
+			helper.SetSectionDefinitions(new[] { TestData.SectionDefinition1, TestData.SectionDefinition2 });
+			helper.SetInstances(new[] { TestData.Instance1, TestData.Instance2 });
+
+			var field2Id = TestData.SectionDefinition1.GetFieldDescriptorByName("Field 2").ID;
+
+			// filter with a long literal while the stored value is an int
+			var filter = DomInstanceExposers.FieldValues.DomInstanceField(field2Id).Equal(123L);
+
+			// act
+			var result = helper.DomInstances.Read(filter);
+
+			// assert - a real DataMiner Agent coerces the numeric types, so the instance matches
+			result.Should().ContainSingle().Which.ID.Should().Be(TestData.Instance1.ID);
+		}
+
+		[TestMethod]
+		public void Read_FieldValueFilter_DoesNotMatchWhenNumericValuesDiffer()
+		{
+			// arrange
+			var helper = DomHelperMock.Create();
+			helper.SetDefinitions(new[] { TestData.Definition1 });
+			helper.SetSectionDefinitions(new[] { TestData.SectionDefinition1, TestData.SectionDefinition2 });
+			helper.SetInstances(new[] { TestData.Instance1, TestData.Instance2 });
+
+			var field2Id = TestData.SectionDefinition1.GetFieldDescriptorByName("Field 2").ID;
+
+			// no instance stores 999
+			var filter = DomInstanceExposers.FieldValues.DomInstanceField(field2Id).Equal(999L);
+
+			// act
+			var result = helper.DomInstances.Read(filter);
+
+			// assert
+			result.Should().BeEmpty();
+		}
+
+		[TestMethod]
+		public void Count_FieldValueFilter_CountsMatchesThroughCoercion()
+		{
+			// arrange
+			var helper = DomHelperMock.Create();
+			helper.SetDefinitions(new[] { TestData.Definition1 });
+			helper.SetSectionDefinitions(new[] { TestData.SectionDefinition1, TestData.SectionDefinition2 });
+			helper.SetInstances(new[] { TestData.Instance1, TestData.Instance2 });
+
+			var field2Id = TestData.SectionDefinition1.GetFieldDescriptorByName("Field 2").ID;
+			var filter = DomInstanceExposers.FieldValues.DomInstanceField(field2Id).Equal(123L);
+
+			// act
+			var count = helper.DomInstances.Count(filter);
+
+			// assert
+			count.Should().Be(1);
+		}
+	}
+}

--- a/Utils.DOM.Tests/DomInstanceInitialStatusTests.cs
+++ b/Utils.DOM.Tests/DomInstanceInitialStatusTests.cs
@@ -1,0 +1,101 @@
+namespace Skyline.DataMiner.Utils.DOM.Tests
+{
+	using System;
+	using System.Linq;
+
+	using FluentAssertions;
+
+	using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+	using Skyline.DataMiner.Net.Apps.DataMinerObjectModel;
+	using Skyline.DataMiner.Utils.DOM.Builders;
+	using Skyline.DataMiner.Utils.DOM.Extensions;
+	using Skyline.DataMiner.Utils.DOM.UnitTesting;
+
+	[TestClass]
+	public class DomInstanceInitialStatusTests
+	{
+		private static readonly DomBehaviorDefinition Behavior = new DomBehaviorDefinitionBuilder()
+			.WithID(new DomBehaviorDefinitionId(Guid.Parse("0f2c2d3a-6d2b-4b58-9b1a-9f7d0e6f1a01")))
+			.WithName("Behavior 1")
+			.WithInitialStatusId("draft")
+			.Build();
+
+		private static readonly DomDefinition Definition = new DomDefinitionBuilder()
+			.WithID(Guid.Parse("a4f0a1b2-3c4d-4e5f-8a9b-0c1d2e3f4a5b"))
+			.WithName("Definition with behavior")
+			.WithDomBehaviorDefinition(Behavior)
+			.Build();
+
+		[TestMethod]
+		public void Create_WithoutStatus_AppliesInitialStatusFromBehavior()
+		{
+			// arrange
+			var helper = DomHelperMock.Create();
+			helper.SetDefinitions(new[] { Definition });
+			helper.SetBehaviorDefinitions(new[] { Behavior });
+
+			var instance = new DomInstanceBuilder()
+				.WithDefinition(Definition)
+				.WithID(Guid.NewGuid())
+				.Build();
+
+			instance.StatusId.Should().BeNullOrEmpty();
+
+			// act
+			var created = helper.DomInstances.Create(instance);
+
+			// assert
+			created.StatusId.Should().Be("draft");
+			helper.DomInstances.ReadAll(Definition)
+				.Single().StatusId.Should().Be("draft");
+		}
+
+		[TestMethod]
+		public void Create_WithExistingStatus_DoesNotOverrideStatus()
+		{
+			// arrange
+			var helper = DomHelperMock.Create();
+			helper.SetDefinitions(new[] { Definition });
+			helper.SetBehaviorDefinitions(new[] { Behavior });
+
+			var instance = new DomInstanceBuilder()
+				.WithDefinition(Definition)
+				.WithID(Guid.NewGuid())
+				.WithStatusID("confirmed")
+				.Build();
+
+			// act
+			var created = helper.DomInstances.Create(instance);
+
+			// assert
+			created.StatusId.Should().Be("confirmed");
+		}
+
+		[TestMethod]
+		public void BulkCreateOrUpdate_WithoutStatus_AppliesInitialStatusFromBehavior()
+		{
+			// arrange
+			var helper = DomHelperMock.Create();
+			helper.SetDefinitions(new[] { Definition });
+			helper.SetBehaviorDefinitions(new[] { Behavior });
+
+			var instance1 = new DomInstanceBuilder()
+				.WithDefinition(Definition)
+				.WithID(Guid.NewGuid())
+				.Build();
+
+			var instance2 = new DomInstanceBuilder()
+				.WithDefinition(Definition)
+				.WithID(Guid.NewGuid())
+				.Build();
+
+			// act
+			helper.DomInstances.CreateOrUpdate(new[] { instance1, instance2 }.ToList());
+
+			// assert
+			var stored = helper.DomInstances.ReadAll(Definition);
+			stored.Should().OnlyContain(i => i.StatusId == "draft");
+		}
+	}
+}

--- a/Utils.DOM/UnitTesting/DomModule.cs
+++ b/Utils.DOM/UnitTesting/DomModule.cs
@@ -47,5 +47,23 @@
 
 			nameDefinition?.SetNameOnDomInstance(instance);
 		}
+
+		public void TrySetInitialStatusOnDomInstance(DomInstance instance)
+		{
+			if (instance is null || !String.IsNullOrEmpty(instance.StatusId) || instance.DomDefinitionId is null)
+			{
+				return;
+			}
+
+			if (!Definitions.TryGetValue(instance.DomDefinitionId, out var definition) || definition.DomBehaviorDefinitionId is null)
+			{
+				return;
+			}
+
+			if (BehaviorDefinitions.TryGetValue(definition.DomBehaviorDefinitionId, out var behavior))
+			{
+				instance.StatusId = behavior.InitialStatusId;
+			}
+		}
 	}
 }

--- a/Utils.DOM/UnitTesting/DomSLNetMessageHandler.cs
+++ b/Utils.DOM/UnitTesting/DomSLNetMessageHandler.cs
@@ -12,8 +12,10 @@
 	using Skyline.DataMiner.Net.Helper;
 	using Skyline.DataMiner.Net.ManagerStore;
 	using Skyline.DataMiner.Net.Messages;
+	using Skyline.DataMiner.Net.Messages.SLDataGateway;
 	using Skyline.DataMiner.Net.Sections;
 	using Skyline.DataMiner.Utils.DOM.Extensions;
+	using Skyline.DataMiner.Utils.DOM.UnitTesting.Querying;
 
 	/// <summary>
 	/// Represents a handler for handling DMS messages related to DOM (Data Object Model) entities.
@@ -287,7 +289,8 @@
 				case ManagerStoreReadRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instances = request.Query.ExecuteInMemory(module.Instances.Values).Select(instance => instance.DeepClone()).ToList();
+						var filtered = CoercingFilterEvaluator.Apply(request.Query.Filter, module.Instances.Values);
+						var instances = request.Query.WithFilter(new TRUEFilterElement<DomInstance>()).ExecuteInMemory(filtered).Select(instance => instance.DeepClone()).ToList();
 						response = new ManagerStoreCrudResponse<DomInstance>(instances);
 						return true;
 					}
@@ -304,6 +307,7 @@
 						((ITrackLastModifiedBy)instance).LastModifiedBy = "DomSLNetMessageHandler";
 
 						module.TrySetNameOnDomInstance(instance);
+						module.TrySetInitialStatusOnDomInstance(instance);
 
 						ValidateInstance(module, instance);
 
@@ -367,7 +371,7 @@
 				case ManagerStoreCountRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var count = request.Query.ExecuteInMemory(module.Instances.Values).LongCount();
+						var count = CoercingFilterEvaluator.Apply(request.Query.Filter, module.Instances.Values).LongCount();
 						response = new ManagerStoreCountResponse<DomInstance>(count);
 						return true;
 					}
@@ -395,6 +399,7 @@
 							((ITrackLastModifiedBy)obj).LastModifiedBy = "DomSLNetMessageHandler";
 
 							module.TrySetNameOnDomInstance(obj);
+							module.TrySetInitialStatusOnDomInstance(obj);
 
 							ValidateInstance(module, obj);
 
@@ -451,7 +456,8 @@
 				case ManagerStoreStartPagingRequest<DomInstance> request:
 					{
 						var module = GetDomModule(request.ModuleId);
-						var instances = request.Filter.ExecuteInMemory(module.Instances.Values).ToList();
+						var filtered = CoercingFilterEvaluator.Apply(request.Filter.Filter, module.Instances.Values);
+						var instances = request.Filter.WithFilter(new TRUEFilterElement<DomInstance>()).ExecuteInMemory(filtered).ToList();
 						var pagingHandler = new DomPagingHandler<DomInstance>(instances.Select(instance => instance.DeepClone()));
 						module.PagingHandlers.TryAdd(pagingHandler.Cookie, pagingHandler);
 

--- a/Utils.DOM/UnitTesting/Querying/CoercingFilterEvaluator.cs
+++ b/Utils.DOM/UnitTesting/Querying/CoercingFilterEvaluator.cs
@@ -1,0 +1,279 @@
+namespace Skyline.DataMiner.Utils.DOM.UnitTesting.Querying
+{
+	using System;
+	using System.Collections;
+	using System.Collections.Generic;
+	using System.Globalization;
+	using System.Linq;
+
+	using Skyline.DataMiner.Net.Messages.SLDataGateway;
+
+	using Comparer = Skyline.DataMiner.Net.Messages.SLDataGateway.Comparer;
+
+	/// <summary>
+	/// Evaluates a <see cref="FilterElement{T}"/> against an in-memory collection while coercing
+	/// numeric and other compatible value types before comparing them.
+	/// </summary>
+	/// <remarks>
+	/// A real DataMiner Agent stores values in typed database columns and lets the database engine
+	/// coerce values (e.g. <see cref="int"/> versus <see cref="long"/>, or <see cref="decimal"/>
+	/// versus <see cref="int"/>) when evaluating a filter. The default in-memory filter evaluation
+	/// performs strict type comparisons, which causes filters built with a literal of a different
+	/// runtime type than the stored value to silently return no matches. This evaluator mirrors the
+	/// coercion behavior of a real DataMiner Agent so that the in-memory handler returns the same
+	/// results.
+	/// </remarks>
+	internal static class CoercingFilterEvaluator
+	{
+		private static readonly HashSet<TypeCode> NumericTypeCodes = new HashSet<TypeCode>
+		{
+			TypeCode.SByte, TypeCode.Byte, TypeCode.Int16, TypeCode.UInt16,
+			TypeCode.Int32, TypeCode.UInt32, TypeCode.Int64, TypeCode.UInt64,
+			TypeCode.Single, TypeCode.Double, TypeCode.Decimal,
+		};
+
+		/// <summary>
+		/// Returns the items that match the supplied filter, applying type coercion during comparison.
+		/// </summary>
+		/// <typeparam name="T">The type of the items being filtered.</typeparam>
+		/// <param name="filter">The filter to evaluate. When <see langword="null"/>, all items match.</param>
+		/// <param name="items">The items to filter.</param>
+		/// <returns>The matching items.</returns>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="items"/> is <see langword="null"/>.</exception>
+		public static List<T> Apply<T>(FilterElement<T> filter, IEnumerable<T> items)
+		{
+			if (items is null)
+			{
+				throw new ArgumentNullException(nameof(items));
+			}
+
+			if (filter is null)
+			{
+				return items.ToList();
+			}
+
+			return items.Where(item => Evaluate(filter, item)).ToList();
+		}
+
+		private static bool Evaluate<T>(FilterElement<T> filter, T item)
+		{
+			switch (filter)
+			{
+				case ANDFilterElement<T> and:
+					return and.subFilters.All(sub => Evaluate(sub, item));
+
+				case ORFilterElement<T> or:
+					return or.subFilters.Length == 0 || or.subFilters.Any(sub => Evaluate(sub, item));
+
+				case NOTFilterElement<T> not:
+					return !Evaluate(not.original, item);
+
+				case TRUEFilterElement<T> _:
+					return true;
+
+				case FALSEFilterElement<T> _:
+					return false;
+
+				case ManagedFilterIdentifier leaf when TryEvaluateLeaf(leaf, item, out var result):
+					return result;
+
+				default:
+					return filter.getLambda()(item);
+			}
+		}
+
+		private static bool TryEvaluateLeaf(ManagedFilterIdentifier leaf, object item, out bool result)
+		{
+			result = false;
+
+			var comparer = leaf.getComparer();
+
+			switch (comparer)
+			{
+				case Comparer.Equals:
+				case Comparer.NotEquals:
+				case Comparer.GT:
+				case Comparer.GTE:
+				case Comparer.LT:
+				case Comparer.LTE:
+					break;
+
+				default:
+					// Contains/NotContains/Regex semantics are left to the default implementation.
+					return false;
+			}
+
+			var exposer = leaf.getFieldName();
+			var expected = leaf.getValue();
+
+			object actual;
+
+			try
+			{
+				actual = exposer.execute(item);
+			}
+			catch
+			{
+				// Mirror the fail-safe behavior: a field that cannot be read does not match.
+				return false;
+			}
+
+			if (actual is IEnumerable list && !(actual is string))
+			{
+				result = EvaluateList(list, comparer, expected);
+				return true;
+			}
+
+			result = ScalarMatches(actual, comparer, expected);
+			return true;
+		}
+
+		private static bool EvaluateList(IEnumerable list, Comparer comparer, object expected)
+		{
+			if (comparer == Comparer.NotEquals)
+			{
+				// A list field is "not equal" to a value when none of its elements equal that value.
+				foreach (var element in list)
+				{
+					if (CoercingEquals(element, expected))
+					{
+						return false;
+					}
+				}
+
+				return true;
+			}
+
+			foreach (var element in list)
+			{
+				if (ScalarMatches(element, comparer, expected))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private static bool ScalarMatches(object actual, Comparer comparer, object expected)
+		{
+			switch (comparer)
+			{
+				case Comparer.Equals:
+					return CoercingEquals(actual, expected);
+
+				case Comparer.NotEquals:
+					return !CoercingEquals(actual, expected);
+
+				case Comparer.GT:
+					return TryCompare(actual, expected, out var gt) && gt > 0;
+
+				case Comparer.GTE:
+					return TryCompare(actual, expected, out var gte) && gte >= 0;
+
+				case Comparer.LT:
+					return TryCompare(actual, expected, out var lt) && lt < 0;
+
+				case Comparer.LTE:
+					return TryCompare(actual, expected, out var lte) && lte <= 0;
+
+				default:
+					return false;
+			}
+		}
+
+		private static bool CoercingEquals(object a, object b)
+		{
+			if (Object.Equals(a, b))
+			{
+				return true;
+			}
+
+			if (a is null || b is null)
+			{
+				return false;
+			}
+
+			if (IsNumeric(a) && IsNumeric(b))
+			{
+				if (IsSpecialFloat(a) || IsSpecialFloat(b))
+				{
+					return false;
+				}
+
+				return ToDecimal(a) == ToDecimal(b);
+			}
+
+			if (a is string sa && b is string sb)
+			{
+				return String.Equals(sa, sb, StringComparison.OrdinalIgnoreCase);
+			}
+
+			// Fall back to an invariant string comparison, mirroring how a database coerces values
+			// (e.g. a stored Guid versus a Guid serialized to a string).
+			return String.Equals(
+				Convert.ToString(a, CultureInfo.InvariantCulture),
+				Convert.ToString(b, CultureInfo.InvariantCulture),
+				StringComparison.OrdinalIgnoreCase);
+		}
+
+		private static bool TryCompare(object a, object b, out int comparison)
+		{
+			comparison = 0;
+
+			if (a is null || b is null)
+			{
+				return false;
+			}
+
+			if (IsNumeric(a) && IsNumeric(b))
+			{
+				if (IsSpecialFloat(a) || IsSpecialFloat(b))
+				{
+					return false;
+				}
+
+				comparison = ToDecimal(a).CompareTo(ToDecimal(b));
+				return true;
+			}
+
+			if (a.GetType() == b.GetType() && a is IComparable sameType)
+			{
+				comparison = sameType.CompareTo(b);
+				return true;
+			}
+
+			try
+			{
+				if (a is IComparable comparable)
+				{
+					var converted = Convert.ChangeType(b, a.GetType(), CultureInfo.InvariantCulture);
+					comparison = comparable.CompareTo(converted);
+					return true;
+				}
+			}
+			catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is OverflowException)
+			{
+				// Values are not comparable after coercion.
+			}
+
+			return false;
+		}
+
+		private static bool IsNumeric(object value)
+		{
+			return value != null && NumericTypeCodes.Contains(Convert.GetTypeCode(value));
+		}
+
+		private static bool IsSpecialFloat(object value)
+		{
+			return (value is double d && (double.IsNaN(d) || double.IsInfinity(d)))
+				|| (value is float f && (float.IsNaN(f) || float.IsInfinity(f)));
+		}
+
+		private static decimal ToDecimal(object value)
+		{
+			return Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+		}
+	}
+}


### PR DESCRIPTION
Add CoercingFilterEvaluator so the in-memory DOM message handler coerces compatible value types (e.g. int vs long) when evaluating DomInstance read/count/paging filters, matching how a real DataMiner Agent evaluates typed columns. Apply the behavior's initial status to newly created DOM instances (single create and bulk create/update) when no status is set. Includes tests for both behaviors.